### PR TITLE
feat: 複数のビデオがあるページではボタンを押した地点の直上のビデオをシークする

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,11 @@ scrapbox.PopupMenu.addButton({
       return null;
     }
 
-    const video = AvailableVideos.findFromDocument(document).topOrNull();
+    const popupMenu = document.querySelector("div.popup-menu");
+
+    const video = AvailableVideos.findFromDocument(
+      document
+    ).nearestAboveElementOrNull(popupMenu);
 
     if (!video) {
       return;

--- a/lib/available-videos.js
+++ b/lib/available-videos.js
@@ -18,6 +18,7 @@ export class AvailableVideos {
   }
 
   topOrNull() {
+    // sort videos by position desc
     this.videos.sort((a, b) => {
       return getTopPos(a) - getTopPos(b);
     });
@@ -27,6 +28,22 @@ export class AvailableVideos {
     }
 
     return this.videos[0];
+  }
+
+  nearestAboveElementOrNull(elem) {
+    // sort videos by position asc
+    this.videos.sort((a, b) => {
+      return getTopPos(b) - getTopPos(a);
+    });
+
+    const elemTop = elem.getBoundingClientRect().top;
+
+    for (const video of this.videos) {
+      const videoTop = getTopPos(video);
+      if (videoTop < elemTop) return video;
+    }
+
+    return null;
   }
 }
 

--- a/lib/available-videos.test.js
+++ b/lib/available-videos.test.js
@@ -32,8 +32,8 @@ function mockIframeElementOfSrc(src) {
 
 describe("AvailableVideos.topOrNull()", () => {
   it("returns the top video", () => {
-    const higher = mockVideoHaveTopYPosOf(100);
-    const lower = mockVideoHaveTopYPosOf(200);
+    const higher = mockVideoWithTopYPosOf(100);
+    const lower = mockVideoWithTopYPosOf(200);
     const availableVideos = new AvailableVideos([lower, higher]);
 
     expect(availableVideos.topOrNull()).toBe(higher);
@@ -44,7 +44,26 @@ describe("AvailableVideos.topOrNull()", () => {
   });
 });
 
-function mockVideoHaveTopYPosOf(y) {
+describe("AvailableVideos.nearestAboveElementOrNull()", () => {
+  it("returns video nearest and above given element", () => {
+    const higher = mockVideoWithTopYPosOf(100);
+    const lower = mockVideoWithTopYPosOf(200);
+    const availableVideos = new AvailableVideos([lower, higher]);
+
+    const higherElem = mockElemWithTopYPosOf(150);
+
+    expect(availableVideos.nearestAboveElementOrNull(higherElem)).toBe(higher);
+
+    const lowerElem = mockElemWithTopYPosOf(250);
+    expect(availableVideos.nearestAboveElementOrNull(lowerElem)).toBe(lower);
+  });
+
+  it("returns null out of empty set", () => {
+    expect(new AvailableVideos([]).topOrNull()).toBe(null);
+  });
+});
+
+function mockVideoWithTopYPosOf(y) {
   return {
     iframe: {
       getBoundingClientRect() {
@@ -52,6 +71,16 @@ function mockVideoHaveTopYPosOf(y) {
           top: y
         };
       }
+    }
+  };
+}
+
+function mockElemWithTopYPosOf(y) {
+  return {
+    getBoundingClientRect() {
+      return {
+        top: y
+      };
     }
   };
 }


### PR DESCRIPTION
## 概要
複数のビデオを埋め込んだページで、2番目以降のビデオもシークできるようにする。

例えば、以下のようにビデオと再生地点ボタンを書いたとき、再生地点1は最初のビデオ、再生地点2は2番目のビデオをシークするボタンとして動作させる。

```scrapbox
[https://youtu.be/foo]

2:35 再生地点1

[https://youtu.be/bar]

5:00 再生地点2
```

## 破壊的変更
複数のビデオを埋め込んでいた場合、これまでは常に一番上に対するシークボタンとして動作していたが、上記の通りの動作となる。